### PR TITLE
Drive-by-wire node

### DIFF
--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -54,12 +54,28 @@ class DBWNode(object):
                                          BrakeCmd, queue_size=1)
 
         # TODO: Create `Controller` object
-        # self.controller = Controller(<Arguments you wish to provide>)
+        self.controller = Controller(vehicle_mass=vehicle_mass,
+                                    fuel_capacity=fuel_capacity,
+                                    brake_deadband=brake_deadband,
+                                    decel_limit=decel_limit,
+                                    accel_limit=accel_limit,
+                                    wheel_radius=wheel_radius,
+                                    wheel_base=wheel_base,
+                                    steer_ratio=steer_ratio,
+                                    max_lat_accel=max_lat_accel,
+                                    max_steer_angle=max_steer_angle)
 
         # TODO: Subscribe to all the topics you need to
         rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb)
         rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cmd_cb)
         rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
+
+        self.current_vel = None
+        self.curr_ang_vel = None
+        self.dbw_enabled = None
+        self.linear_vel = None
+        self.angular_vel = None
+        self.throttle = self.steering = self.brake = 0
 
         self.loop()
 
@@ -68,13 +84,13 @@ class DBWNode(object):
         while not rospy.is_shutdown():
             # TODO: Get predicted throttle, brake, and steering using `twist_controller`
             # You should only publish the control commands if dbw is enabled
-            # throttle, brake, steering = self.controller.control(<proposed linear velocity>,
-            #                                                     <proposed angular velocity>,
-            #                                                     <current linear velocity>,
-            #                                                     <dbw status>,
-            #                                                     <any other argument you need>)
-            # if <dbw is enabled>:
-            #   self.publish(throttle, brake, steer)
+            if not None in (self.current_vel, self.linear_vel, self.angular_vel):
+                self.throttle, self.brake, self.steering = self.controller.control(self.current_vel,
+                                                                        self.dbw_enabled,
+                                                                        self.linear_vel,
+                                                                        self.angular_vel)
+            if self.dbw_enabled: 
+                self.publish(self.throttle, self.brake, self.steering)
             rate.sleep()
 
     def publish(self, throttle, brake, steer):
@@ -95,11 +111,14 @@ class DBWNode(object):
         bcmd.pedal_cmd = brake
         self.brake_pub.publish(bcmd)
 
-    def current_velocity_cb(self):
-        pass
-    def twist_cmd_cb(self):
-        pass
-    def dbw_enabled_cb(self):
-        pass
+    def current_velocity_cb(self, msg):
+        self.current_vel = msg.twist.linear.x
+
+    def twist_cmd_cb(self, msg):
+        self.linear_vel = msg.twist.linear.x
+        self.angular_vel = msg.twist.angular.z
+
+    def dbw_enabled_cb(self, msg):
+        self.dbw_enabled = msg
 if __name__ == '__main__':
     DBWNode()

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -57,6 +57,9 @@ class DBWNode(object):
         # self.controller = Controller(<Arguments you wish to provide>)
 
         # TODO: Subscribe to all the topics you need to
+        rospy.Subscriber('/current_velocity', TwistStamped, self.current_velocity_cb)
+        rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cmd_cb)
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
 
         self.loop()
 
@@ -92,6 +95,11 @@ class DBWNode(object):
         bcmd.pedal_cmd = brake
         self.brake_pub.publish(bcmd)
 
-
+    def current_velocity_cb(self):
+        pass
+    def twist_cmd_cb(self):
+        pass
+    def dbw_enabled_cb(self):
+        pass
 if __name__ == '__main__':
     DBWNode()

--- a/ros/src/twist_controller/twist_controller.py
+++ b/ros/src/twist_controller/twist_controller.py
@@ -1,14 +1,71 @@
+from pid import PID
+from yaw_controller import YawController
+from lowpass import LowPassFilter
+import rospy
 
 GAS_DENSITY = 2.858
 ONE_MPH = 0.44704
 
 
 class Controller(object):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, vehicle_mass, fuel_capacity, brake_deadband, decel_limit,
+        accel_limit, wheel_radius, wheel_base, steer_ratio, max_lat_accel, max_steer_angle):
+        
         # TODO: Implement
-        pass
+        self.yaw_controller =  YawController(wheel_base, steer_ratio, 0.1, max_lat_accel, max_steer_angle)
 
-    def control(self, *args, **kwargs):
+        kp = 0.3
+        ki = 0.1
+        kd = 0.
+        mn = 0. #Minimum throttle value
+        mx = 0.2 # max throttle value
+        self.throttle_controller = PID(kp, ki, kd, mn, mx)
+
+        tau = 0.5 # (1/(2pi*tau) = cutoff frequency
+        ts = 0.02 # sampling time
+        self.vel_lpf = LowPassFilter(tau, ts)
+
+        self.vehicle_mass = vehicle_mass
+        self.fuel_capacity = fuel_capacity
+        self.brake_deadband = brake_deadband
+        self.decel_limit = decel_limit
+        self.accel_limit = accel_limit
+        self.wheel_radius = wheel_radius
+
+        self.last_time = rospy.get_time()
+
+    def control(self, current_vel, dbw_enabled, linear_vel, angular_vel):
         # TODO: Change the arg, kwarg list to suit your needs
         # Return throttle, brake, steer
-        return 1., 0., 0.
+        if not dbw_enabled:
+            self.throttle_controller.reset()
+            return 0., 0., 0.
+        
+        current_vel = self.vel_lpf.filt(current_vel)
+
+        # some commented code
+
+        steering = self.yaw_controller.get_steering(linear_vel, angular_vel, current_vel)
+
+        vel_error = linear_vel - current_vel
+        self.last_vel = current_vel
+
+        current_time = rospy.get_time()
+        sample_time = current_vel - self.last_time
+        self.last_time = current_time
+
+        throttle = self.throttle_controller.step(vel_error, sample_time)
+        brake = 0
+
+        if linear_vel == 0. and current_vel < 0.1:
+            throttle = 0
+            brake = 700 #N*m - to hold the car in place if we are stopped at a light. Acceleration - 1m/s^2
+
+        elif throttle < .1 and vel_error < 0:
+            throttle = 0
+            decel = max(vel_error, self.decel_limit)
+            brake = abs(decel)*self.vehicle_mass*self.wheel_radius
+
+        return throttle, brake, steering
+
+


### PR DESCRIPTION
DBW Node Overview

Once messages are being published to `/final_waypoints`, the vehicle's waypoint follower will publish twist commands to the `/twist_cmd` topic. The goal for this part of the project is to implement the drive-by-wire node `dbw_node.py` which will subscribe to `/twist_cmd` and use various controllers to provide appropriate throttle, brake, and steering commands. These commands can then be published to the following topics:
-  `/vehicle/throttle_cmd`
-  `/vehicle/brake_cmd`
- `/vehicle/steering_cmd`

Since a safety driver may take control of the car during testing, you should not assume that the car is always following your commands. If a safety driver does take over, your PID controller will mistakenly accumulate error, so you will need to be mindful of DBW status. The DBW status can be found by subscribing to `/vehicle/dbw_enabled`. 